### PR TITLE
Fix bizarre sorting problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## Version 1.0.2
+
+* Fixed an issue where sorting order of filters differed in R 3.0 versus 3.1,
+  resulting in malformed Looker queries.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: LookR
 Type: Package
 Title: An Interface for the Looker API
-Version: 1.0.1
+Version: 1.0.2
 Date: 2013-12-08
 Author: Scott Hoover
 Maintainer: Scott Hoover <scott@looker.com>

--- a/R/query.R
+++ b/R/query.R
@@ -14,6 +14,13 @@ LookerQuery = function(dictionary, query, fields, filters = NA, limit = NA, outp
 		} else { 
       filters2 <- sapply(strsplit(filters, ":"), `[[`, 1)
       filters2 <- strsplit(filters2, ".", fixed = TRUE)
+      # In R 3.1, the is.unsorted function was changed to ignore
+      # non alpha-numeric characters. Thus, for example,
+      # is.unsorted(c("fooa", "foo_bar")) used to be TRUE in R <= 3.0
+      # but now became FALSE, resulting in the wrong sorting order
+      # for some Looker filters. We fix this by stripping all
+      # non-alphanumeric characters when sorting.
+      filters2 <- gsub("[^0-9a-zA-Z]", "", filters2)
 			Looker$filters <- filters[order(sapply(filters2, `[[`, 1), sapply(filters2, `[[`, 2))]
     }
 

--- a/R/query.R
+++ b/R/query.R
@@ -20,7 +20,7 @@ LookerQuery = function(dictionary, query, fields, filters = NA, limit = NA, outp
       # but now became FALSE, resulting in the wrong sorting order
       # for some Looker filters. We fix this by stripping all
       # non-alphanumeric characters when sorting.
-      filters2 <- lapply(filters, gsub, pattern = "[^0-9a-zA-Z]", replacement = "")
+      filters2 <- lapply(filters2, gsub, pattern = "[^0-9a-zA-Z]", replacement = "")
 			Looker$filters <- filters[order(sapply(filters2, `[[`, 1), sapply(filters2, `[[`, 2))]
     }
 

--- a/R/query.R
+++ b/R/query.R
@@ -20,7 +20,7 @@ LookerQuery = function(dictionary, query, fields, filters = NA, limit = NA, outp
       # but now became FALSE, resulting in the wrong sorting order
       # for some Looker filters. We fix this by stripping all
       # non-alphanumeric characters when sorting.
-      filters2 <- gsub("[^0-9a-zA-Z]", "", filters2)
+      filters2 <- lapply(filters, gsub, pattern = "[^0-9a-zA-Z]", replacement = "")
 			Looker$filters <- filters[order(sapply(filters2, `[[`, 1), sapply(filters2, `[[`, 2))]
     }
 


### PR DESCRIPTION
In R 3.1, the `is.unsorted` function was changed to ignore
non alpha-numeric characters. Thus, for example,
`is.unsorted(c("fooa", "foo_bar")`) used to be `TRUE` in R <= 3.0
but now became `FALSE`, resulting in the wrong sorting order
for some Looker filters. We fix this by stripping all
non-alphanumeric characters when sorting.
